### PR TITLE
Adjust m3u8 target duration

### DIFF
--- a/src/orca_hls_utils/DateRangeHLSStream.py
+++ b/src/orca_hls_utils/DateRangeHLSStream.py
@@ -36,7 +36,7 @@ class DateRangeHLSStream():
     real_time = if False, get data as soon as possible, if true wait for polling interval before pulling
     """
 
-    def __init__(self, stream_base, polling_interval, start_unix_time, end_unix_time, wav_dir, real_time=False):
+    def __init__(self, stream_base, polling_interval, start_unix_time, end_unix_time, wav_dir, overwrite_output=False, real_time=False):
         """
 
         """
@@ -144,7 +144,7 @@ class DateRangeHLSStream():
         # read the concatenated .ts and write to wav
         stream = ffmpeg.input(os.path.join(tmp_path, Path(hls_file)))
         stream = ffmpeg.output(stream, wav_file_path)
-        ffmpeg.run(stream, quiet=False)
+        ffmpeg.run(stream, overwrite_ouput=overwrite_output, quiet=False)
 
         # clear the tmp_path
         os.system(f'rm -rf {tmp_path}')

--- a/src/orca_hls_utils/DateRangeHLSStream.py
+++ b/src/orca_hls_utils/DateRangeHLSStream.py
@@ -107,7 +107,7 @@ class DateRangeHLSStream():
         num_segments_in_wav_duration = math.ceil(self.polling_interval_in_seconds/target_duration)
 
         # calculate the start index by computing the current time - start of current folder
-        segment_start_index = math.ceil(datetime_utils.get_difference_between_times_in_seconds(self.current_clip_start_time, current_folder)/stream_obj.target_duration)
+        segment_start_index = math.ceil(datetime_utils.get_difference_between_times_in_seconds(self.current_clip_start_time, current_folder)/target_duration)
         segment_end_index = segment_start_index + num_segments_in_wav_duration
 
         if segment_end_index > num_total_segments:

--- a/src/orca_hls_utils/DateRangeHLSStream.py
+++ b/src/orca_hls_utils/DateRangeHLSStream.py
@@ -33,6 +33,7 @@ class DateRangeHLSStream():
     start_unix_time
     end_unix_time
     wav_dir
+    overwrite_output: allows ffmpeg to overwrite output, default is False
     real_time = if False, get data as soon as possible, if true wait for polling interval before pulling
     """
 

--- a/src/orca_hls_utils/DateRangeHLSStream.py
+++ b/src/orca_hls_utils/DateRangeHLSStream.py
@@ -47,7 +47,7 @@ class DateRangeHLSStream():
         self.start_unix_time = start_unix_time
         self.end_unix_time = end_unix_time
         self.wav_dir = wav_dir
-        self.overwrite_ouput = overwrite_output
+        self.overwrite_output = overwrite_output
         self.real_time = real_time
         self.is_end_of_stream = False
 
@@ -145,7 +145,7 @@ class DateRangeHLSStream():
         # read the concatenated .ts and write to wav
         stream = ffmpeg.input(os.path.join(tmp_path, Path(hls_file)))
         stream = ffmpeg.output(stream, wav_file_path)
-        ffmpeg.run(stream, overwrite_ouput=overwrite_output, quiet=False)
+        ffmpeg.run(stream, overwrite_ouput=self.overwrite_output, quiet=False)
 
         # clear the tmp_path
         os.system(f'rm -rf {tmp_path}')

--- a/src/orca_hls_utils/DateRangeHLSStream.py
+++ b/src/orca_hls_utils/DateRangeHLSStream.py
@@ -145,7 +145,7 @@ class DateRangeHLSStream():
         # read the concatenated .ts and write to wav
         stream = ffmpeg.input(os.path.join(tmp_path, Path(hls_file)))
         stream = ffmpeg.output(stream, wav_file_path)
-        ffmpeg.run(stream, overwrite_ouput=self.overwrite_output, quiet=False)
+        ffmpeg.run(stream, overwrite_output=self.overwrite_output, quiet=False)
 
         # clear the tmp_path
         os.system(f'rm -rf {tmp_path}')

--- a/src/orca_hls_utils/DateRangeHLSStream.py
+++ b/src/orca_hls_utils/DateRangeHLSStream.py
@@ -103,7 +103,8 @@ class DateRangeHLSStream():
             (self.stream_base), (current_folder))
         stream_obj = m3u8.load(stream_url)
         num_total_segments = len(stream_obj.segments)
-        num_segments_in_wav_duration = math.ceil(self.polling_interval_in_seconds/stream_obj.target_duration)
+        target_duration = sum([item.duration for item in stream_obj.segments])/len(num_total_segments)
+        num_segments_in_wav_duration = math.ceil(self.polling_interval_in_seconds/target_duration)
 
         # calculate the start index by computing the current time - start of current folder
         segment_start_index = math.ceil(datetime_utils.get_difference_between_times_in_seconds(self.current_clip_start_time, current_folder)/stream_obj.target_duration)

--- a/src/orca_hls_utils/DateRangeHLSStream.py
+++ b/src/orca_hls_utils/DateRangeHLSStream.py
@@ -103,7 +103,7 @@ class DateRangeHLSStream():
             (self.stream_base), (current_folder))
         stream_obj = m3u8.load(stream_url)
         num_total_segments = len(stream_obj.segments)
-        target_duration = sum([item.duration for item in stream_obj.segments])/len(num_total_segments)
+        target_duration = sum([item.duration for item in stream_obj.segments])/num_total_segments
         num_segments_in_wav_duration = math.ceil(self.polling_interval_in_seconds/target_duration)
 
         # calculate the start index by computing the current time - start of current folder

--- a/src/orca_hls_utils/DateRangeHLSStream.py
+++ b/src/orca_hls_utils/DateRangeHLSStream.py
@@ -47,6 +47,7 @@ class DateRangeHLSStream():
         self.start_unix_time = start_unix_time
         self.end_unix_time = end_unix_time
         self.wav_dir = wav_dir
+        self.overwrite_ouput = overwrite_output
         self.real_time = real_time
         self.is_end_of_stream = False
 


### PR DESCRIPTION
This PR modifies the calculation of target_duration. It is `11` in the `m3u8` files, while the files are about 10 sec long. So instead the target duration is calculated as average of all files in the folder. This change pulls the files as expected.