### PR TITLE
Various fixes

### DIFF
--- a/src/orca_hls_utils/HLSStream.py
+++ b/src/orca_hls_utils/HLSStream.py
@@ -91,7 +91,7 @@ class HLSStream:
         target_duration = round(
             sum([item.duration for item in stream_obj.segments])
             / num_total_segments,
-            3
+            3,
         )
         num_segments_in_wav_duration = math.ceil(
             self.polling_interval / target_duration
@@ -161,10 +161,10 @@ class HLSStream:
         hls_file_path = os.path.join(tmp_path, hls_file)
 
         # Combine .ts files into one .ts file
-        with open(hls_file_path, 'wb') as outfile:
+        with open(hls_file_path, "wb") as outfile:
             for fname in file_names:
                 segment_path = os.path.join(tmp_path, fname)
-                with open(segment_path, 'rb') as infile:
+                with open(segment_path, "rb") as infile:
                     outfile.write(infile.read())
 
         # read the concatenated .ts and write to wav
@@ -174,8 +174,8 @@ class HLSStream:
             ffmpeg.run(stream, quiet=True)
         except ffmpeg.Error as e:
             print("FFmpeg command failed.")
-            print("stdout:", e.stdout.decode('utf8', errors='ignore'))
-            print("stderr:", e.stderr.decode('utf8', errors='ignore'))
+            print("stdout:", e.stdout.decode("utf8", errors="ignore"))
+            print("stderr:", e.stderr.decode("utf8", errors="ignore"))
             raise
 
         # clear the tmp_path


### PR DESCRIPTION
* Remove unnecessary delay on first iteration (tested by aifororcas-livesystem)
* Replace Linux-only code with OS-agnostic python code to enable running on Windows
* Round the target_duration to an integral number of milliseconds (in practice for all hydrophone nodes today, it's a round number of seconds, but keep the code in this repo robust enough to handle a polling period in milliseconds)
* Fix a missing "return" in line 117
* Fix off-by-one error in line 123 to avoid trying to read past end of current file list.  This bug didn't really show up before due to the timestamp drift issue but now that that's fixed the script does try to read the latest files, causing this bug to show up.
* Update clip timestamp to be computed from the actual files rather than from the current time.  This improves the timestamp granularity from a 10-second granularity to a 1-second granularity.