### PR TITLE
Disable release trigger in pipy-release workflow

### DIFF
--- a/.github/workflows/pipy-release.yml
+++ b/.github/workflows/pipy-release.yml
@@ -1,8 +1,8 @@
 name: Publish Python package
 
 on:
-  release:
-    types: [published]
+  # release:
+  #  types: [published]
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
Comment out release trigger for published types.